### PR TITLE
Fixing IOError management, causing AttributeError (#24)

### DIFF
--- a/cpapi/mgmt_api.py
+++ b/cpapi/mgmt_api.py
@@ -700,7 +700,7 @@ class APIClient:
                 else:
                     print(e.message, file=sys.stderr)
             except IOError as e:
-                print("Couldn't open file: " + filename + "\n" + e.message, file=sys.stderr)
+                print("Couldn't open file: " + filename + "\n" + e.strerror, file=sys.stderr)
             except Exception as e:
                 print(e, file=sys.stderr)
             else:

--- a/cpapi/mgmt_api.py
+++ b/cpapi/mgmt_api.py
@@ -650,7 +650,7 @@ class APIClient:
                     print(e.message, file=sys.stderr)
                 return False
             except IOError as e:
-                print("Couldn't open file: " + filename + "\n" + e.message, file=sys.stderr)
+                print("Couldn't open file: " + filename + "\n" + e.strerror, file=sys.stderr)
                 return False
             except Exception as e:
                 print(e, file=sys.stderr)
@@ -669,7 +669,8 @@ class APIClient:
                 filedump.close()
             return True
         except IOError as e:
-            print("Couldn't open file: " + filename + " for writing.\n" + e.message, file=sys.stderr)
+            print("Couldn't open file: " + filename + " for writing.\n" + e.strerror, file=sys.stderr)
+            return False
         except Exception as e:
             print(e, file=sys.stderr)
             return False


### PR DESCRIPTION
As this issue pointed out: https://github.com/CheckPointSW/cp_mgmt_api_python_sdk/issues/24

The management of `IOError` prints a message that requires the attribute `message` to be set, which is non-existent on `IOError`.  This pull request fixes this issue.