### PR TITLE
Adding timeout capability to api_call

### DIFF
--- a/cpapi/api_exceptions.py
+++ b/cpapi/api_exceptions.py
@@ -12,3 +12,7 @@ class APIClientException(APIException):
     def __init__(self, value):
         APIException.__init__(self, value, None)
 
+
+class TimeoutException(APIException):
+    def __init__(self, value):
+        APIException.__init__(self, value, None)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cpapi",
-    version="1.1.1",
+    version="1.1.2",
     author="API team",
     author_email="api_team@checkpoint.com",
     description="Check Point Management API SDK",


### PR DESCRIPTION
Working on a project using this api, we recently faced the need to add a timeout feature to `api_call`.  This allowed us to cancel some calls that wouldn't end (for reason not related to this api).  This is working great for us so far, and we propose to merge it upstream.

The change made is simple, when calling `api_call`, an optional (no backward compatibility issue) field called timeout can be filled.  Any positive integer will be translated as a timeout (in seconds) before which the call has to finish.  Otherwise the request will be terminated and a  `TimeoutException` (inheriting from `ApiException`) will be raised.