### PR TITLE
fix login as root with non-standard API port

### DIFF
--- a/cpapi/mgmt_api.py
+++ b/cpapi/mgmt_api.py
@@ -239,6 +239,11 @@ class APIClient:
             except (ValueError, subprocess.CalledProcessError):
                 port = self.get_port()
 
+            else:
+                # may be a non-standard port, update the configuration to reflect this,
+                # required for follow-up HTTPS connections
+                self.set_port(port)
+
         try:
             # This simple dict->cli format works only because the login command doesn't require
             # any complex parameters like objects and lists


### PR DESCRIPTION
Hello,

I've run into an issue when trying to use `login_as_root()`
with a non-standard API port, so here's a suggested fix for that:


---


When using a non-standard API port such as 4443,
`login_as_root()` retrieves it correctly by executing `api_get_port.py`
and succeeds to log in using `mgmt_cli login -r ... --port <port>`.

The 'root' login mode bypasses the regular transport mechanism
and therefore no HTTPS connection has been created yet.

Any subsequent API call (`api_call()`, `api_query()`, ...)
fails as soon as `get_https_connection()` is called,
which in turn calls `create_https_connection()`.

The reason is that `create_https_connection()` queries
the port to which a connection should be made
and `get_port()` will always report 443 in that case.

This results in a `ConnectionRefusedError`
since the mgmt API server is listeneing on 4443 and not 443.

Example from a CPM running R80.20
(the issue exists regardless of version, though):

```
  Traceback (most recent call last):
    ...
    File "<REDACTED>/pym/cpapi/mgmt_api.py", line 314, in api_call
      conn = self.get_https_connection()
    File "<REDACTED>/pym/cpapi/mgmt_api.py", line 749, in get_https_connection
      self.conn = self.create_https_connection()
    File "<REDACTED>/pym/cpapi/mgmt_api.py", line 743, in create_https_connection
      conn.connect()
    File "<REDACTED>/pym/cpapi/mgmt_api.py", line 764, in connect
      http_client.HTTPConnection.connect(self)
    File "/opt/CPsuite-R80.20/fw1/Python/lib/python3.7/http/client.py", line 938, in connect
      (self.host,self.port), self.timeout, self.source_address)
    File "/opt/CPsuite-R80.20/fw1/Python/lib/python3.7/socket.py", line 727, in create_connection
      raise err
    File "/opt/CPsuite-R80.20/fw1/Python/lib/python3.7/socket.py", line 716, in create_connection
      sock.connect(sa)
  ConnectionRefusedError: [Errno 111] Connection refused
```

When used in `with APIClient(...)` context,
a second `ConnectionRefusedError` will be raised due to `__exit__()` trying to log out.

This commit suggests remembering the port retrieved during
`login_as_root()` and using that for establishing the HTTPS connection.

**Please note that the is_port_default() notion gets lost** for all` login_as_root()`
scenarios (both standard and non-standard port) due to this change.